### PR TITLE
Bump numpy from 1.15.4 to 1.22.0 in /stats

### DIFF
--- a/stats/requirements.txt
+++ b/stats/requirements.txt
@@ -4,7 +4,7 @@ chardet==3.0.4
 eosapi==0.4
 funcy==1.11
 idna==2.7
-numpy==1.15.4
+numpy==1.22.0
 pandas==0.23.4
 prettytable==0.7.2
 pyeos-client==0.1.9


### PR DESCRIPTION
### Description

In this pull request, the `numpy` version in the `stats/requirements.txt` file is being updated from `1.15.4` to `1.22.0`. This change is being made to keep the dependencies up-to-date and ensure compatibility with other libraries.

The specific changes in this pull request are:
- Modifying the `numpy` version in `stats/requirements.txt` from `1.15.4` to `1.22.0`