### PR TITLE
Bump certifi from 2018.10.15 to 2022.12.7 in /stats

### DIFF
--- a/stats/requirements.txt
+++ b/stats/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4==4.7.1
-certifi==2018.10.15
+certifi==2022.12.7
 chardet==3.0.4
 eosapi==0.4
 funcy==1.11


### PR DESCRIPTION
### Description

This pull request modifies the `stats/requirements.txt` file by updating the version of the `certifi` package.

Changes:
- Updated the `certifi` package version from `2018.10.15` to `2022.12.7`